### PR TITLE
(fix): Update code to utilize latest libcloud features

### DIFF
--- a/demo/web/app.py
+++ b/demo/web/app.py
@@ -33,7 +33,7 @@ class Root:
             apikey = cookie['monitoring_apikey'].value
 
         raxMon = get_driver(Provider.RACKSPACE)
-        driver = raxMon(username, apikey, ex_force_base_url="https://ele-api.k1k.me/v1.0")
+        driver = raxMon(username, apikey) #, ex_force_base_url="https://monitoring.api.rackspacecloud.com/v1.0")
         return driver
 
     @cherrypy.expose
@@ -62,4 +62,4 @@ class Root:
 
 
 cherrypy.tree.mount(Root(), script_name='/')
-cherrypy.config.update({'engine.autoreload_on': False})
+cherrypy.config.update({'engine.autoreload_on': False, 'server.socket_host': '0.0.0.0'})

--- a/rackspace_monitoring/__init__.py
+++ b/rackspace_monitoring/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ['__version__']
-__version__ = '0.6.5'
+__version__ = '0.7.0'

--- a/setup.py
+++ b/setup.py
@@ -171,7 +171,7 @@ setup(
     description='Client library for Rackspace Cloud Monitoring',
     author='Rackspace, Inc.',
     author_email='monitoring@rackspace.com',
-    install_requires=['apache-libcloud >= 0.14, <0.16'],
+    install_requires=['apache-libcloud >= 0.17'],
     packages=[
         'rackspace_monitoring',
         'rackspace_monitoring.drivers',

--- a/setup.py
+++ b/setup.py
@@ -171,7 +171,7 @@ setup(
     description='Client library for Rackspace Cloud Monitoring',
     author='Rackspace, Inc.',
     author_email='monitoring@rackspace.com',
-    install_requires=['apache-libcloud >= 0.17'],
+    install_requires=['apache-libcloud >= 0.17', 'backports.ssl_match_hostname'],
     packages=[
         'rackspace_monitoring',
         'rackspace_monitoring.drivers',

--- a/test/test_rackspace.py
+++ b/test/test_rackspace.py
@@ -414,7 +414,8 @@ class RackspaceTests(unittest.TestCase):
         driver = RackspaceMonitoringDriver(key=RACKSPACE_PARAMS[0],
                                            secret=RACKSPACE_PARAMS[1])
         driver.list_entities()
-        self.assertEqual(driver.connection._ex_force_base_url, None)
+        self.assertEqual(driver.connection._ex_force_base_url,
+                         'https://monitoring.api.rackspacecloud.com/v1.0/23213')
 
 
 class RackspaceMockHttp(MockHttpTestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -9,4 +9,5 @@ deps = mock
 [testenv]
 deps = mock
        apache-libcloud
+       backports.ssl_match_hostname
 commands = python setup.py test


### PR DESCRIPTION
In 0.16.0 of apache-libcloud, there was an update from
OpenstackServiceCatalog to OpenStackServiceCatalogEntry.

The update also removed tenant_id from get_endpoints()
response.  This fix removed retrieval of tenant_id from
service catalog response object and instead parsed the
monitoring url to retrieve tenant_id that way.

https://libcloud.readthedocs.io/en/latest/upgrade_notes.html?highlight=openstackservicecatalogentryendpoint#libcloud-0-16-0

```
OpenStackServiceCatalog class has been refactored to store parsed
catalog entries in a structured format (OpenStackServiceCatalogEntry and
OpenStackServiceCatalogEntryEndpoint class). Previously entries were
stored in an unstructured form in a dictionary. All the catalog entries
can be retrieved by using OpenStackServiceCatalog.get_entris method.
```

Also, fixed up the old and crusty demo url