### PR TITLE
Cap apache-libcloud <2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "2.6"
   - "2.7"
-  - "3.2"
+  - "3.3"
 
 before_install: 
   - cp test/secrets.py-dist test/secrets.py

--- a/setup.py
+++ b/setup.py
@@ -171,7 +171,8 @@ setup(
     description='Client library for Rackspace Cloud Monitoring',
     author='Rackspace, Inc.',
     author_email='monitoring@rackspace.com',
-    install_requires=['apache-libcloud >= 0.17', 'backports.ssl_match_hostname'],
+    install_requires=['apache-libcloud >= 0.17,<2.0',
+                      'backports.ssl_match_hostname'],
     packages=[
         'rackspace_monitoring',
         'rackspace_monitoring.drivers',


### PR DESCRIPTION
Currently the apache-libcloud dep only has a lower bound, however it
this package fails with v2.0 so adding an upper bound of <2.0

Fixes: #53 
Also related to racker/rackspace-monitoring-cli#87