### PR TITLE
bump to python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "2.6"
   - "2.7"
-  - "3.2"
+  - "3.3"
 
 before_install: 
   - cp test/secrets.py-dist test/secrets.py


### PR DESCRIPTION
Trying to fix [CI tests that fail](https://travis-ci.org/racker/rackspace-monitoring/jobs/238246665#L185) with Python `3.3` required, but we only test Python `3.2`.

```
raise RuntimeError("Python 3.3 or later is required")
RuntimeError: Python 3.3 or later is required
```