### PR TITLE
Add active/scheduled suppression fields to entity/check/alarm objects…

### DIFF
--- a/rackspace_monitoring/base.py
+++ b/rackspace_monitoring/base.py
@@ -64,7 +64,8 @@ class Entity(object):
     Represents an entity to be monitored.
     """
 
-    def __init__(self, id, label, ip_addresses, uri, driver, agent_id=None, extra=None):
+    def __init__(self, id, label, ip_addresses, uri, driver, agent_id=None,
+            extra=None, active_suppressions=None, scheduled_suppressions=None):
         """
         @type label: C{str}
         @param label: Object label (must be unique per container).
@@ -91,6 +92,8 @@ class Entity(object):
         self.ip_addresses = ip_addresses or []
         self.driver = driver
         self.agent_id = agent_id
+        self.active_suppressions = active_suppressions or []
+        self.scheduled_suppressions = scheduled_suppressions or []
 
     def update(self, data, **kwargs):
         self.driver.update_entity(entity=self, data=data, **kwargs)
@@ -188,7 +191,8 @@ class NotificationType(object):
 
 class Alarm(object):
     def __init__(self, id, check_id, criteria, driver, entity_id, label=None,
-                 notification_plan_id=None, confd_name=None, confd_hash=None, metadata=None):
+                 notification_plan_id=None, confd_name=None, confd_hash=None, metadata=None,
+                 active_suppressions=None, scheduled_suppressions=None):
         self.id = id
         self.check_id = check_id
         self.criteria = criteria
@@ -199,6 +203,8 @@ class Alarm(object):
         self.confd_name = confd_name
         self.confd_hash = confd_hash
         self.metadata = metadata
+        self.active_suppressions = active_suppressions or []
+        self.scheduled_suppressions = scheduled_suppressions or []
 
     def update(self, data):
         self.driver.update_alarm(alarm=self, data=data)
@@ -213,7 +219,8 @@ class Alarm(object):
 class Check(object):
     def __init__(self, id, label, timeout, period, monitoring_zones,
                  target_alias, target_resolver, type, details,
-                 entity_id, disabled, driver, confd_name=None, confd_hash=None, metadata=None):
+                 entity_id, disabled, driver, confd_name=None, confd_hash=None, metadata=None,
+                 active_suppressions=None, scheduled_suppressions=None):
         self.id = id
         self.label = label
         self.timeout = timeout
@@ -229,6 +236,8 @@ class Check(object):
         self.confd_hash = confd_hash
         self.metadata = metadata
         self.driver = driver
+        self.active_suppressions = active_suppressions or []
+        self.scheduled_suppressions = scheduled_suppressions or []
 
     def update(self, data):
         self.driver.update_check(check=self, data=data)

--- a/test/fixtures/rackspace/v1.0/alarms.json
+++ b/test/fixtures/rackspace/v1.0/alarms.json
@@ -5,7 +5,9 @@
             "check_id": "chhJwYeArX",
             "criteria": "if (metric['status'] == 404) { return CRITICAL }",
             "label": "Status code",
-            "notification_plan_id": "npIXxOAn5"
+            "notification_plan_id": "npIXxOAn5",
+            "active_suppressions": [],
+            "scheduled_suppressions": []
         }
     ],
     "metadata": {

--- a/test/fixtures/rackspace/v1.0/checks.json
+++ b/test/fixtures/rackspace/v1.0/checks.json
@@ -16,7 +16,9 @@
             "target_alias": "1",
             "target_hostname": null,
             "target_resolver": null,
-            "disabled": false
+            "disabled": false,
+            "active_suppressions": [],
+            "scheduled_suppressions": []
         }
     ],
     "metadata": {

--- a/test/fixtures/rackspace/v1.0/entities.json
+++ b/test/fixtures/rackspace/v1.0/entities.json
@@ -7,27 +7,35 @@
                 "1": "127.0.0.1"
             },
             "uri": "http://ffo.com/uri/bar/12312",
-            "metadata": {}
+            "metadata": {},
+            "active_suppressions": [],
+            "scheduled_suppressions": []
         },
         {
             "id": "en8Xmk5lv1",
             "label": "foooo",
             "ip_addresses": {},
             "uri": null,
-            "metadata": {}
+            "metadata": {},
+            "active_suppressions": [],
+            "scheduled_suppressions": []
         },
         {
             "id": "enBq9glhau",
             "label": "foooo",
             "ip_addresses": {},
             "uri": null,
-            "metadata": {}
+            "metadata": {},
+            "active_suppressions": [],
+            "scheduled_suppressions": []
         },
         {
             "id": "enQJCKqUZ9",
             "label": "foooo",
             "ip_addresses": {},
-            "metadata": {}
+            "metadata": {},
+            "active_suppressions": [],
+            "scheduled_suppressions": []
         },
         {
             "id": "endYGlC6Gt",
@@ -36,14 +44,18 @@
                 "default": "86.58.76.208"
             },
             "uri": null,
-            "metadata": null
+            "metadata": null,
+            "active_suppressions": [],
+            "scheduled_suppressions": []
         },
         {
             "id": "enjoLD0Al3",
             "label": "foooo",
             "ip_addresses": {},
             "uri": null,
-            "metadata": {}
+            "metadata": {},
+            "active_suppressions": [],
+            "scheduled_suppressions": []
         }
     ],
     "metadata": {


### PR DESCRIPTION
… as returned by API. Added active/scheduled suppression fields to test fixtures as well.
I don't have a full testing suite but py26 and py27 run successfully.

Ran 36 tests in 0.133s

OK
___________________________________________________________ summary ____________________________________________________________
  py26: commands succeeded
  congratulations :)

Ran 36 tests in 0.068s

OK
___________________________________________________________ summary ____________________________________________________________
  py27: commands succeeded
  congratulations :)